### PR TITLE
Alter ocean core, seaice core, and e3sm files

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -4,6 +4,7 @@
 
 
 <!-- run_modes -->
+<!-- alter namelist file !! -->
 <config_ocean_run_mode>'forward'</config_ocean_run_mode>
 
 <!-- time_management -->

--- a/components/mpas-source/src/core_ocean/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-source/src/core_ocean/shared/mpas_ocn_diagnostics.F
@@ -1,3 +1,4 @@
+!!! Add line within ocean core
 ! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
 !

--- a/components/mpas-source/src/core_seaice/shared/mpas_seaice_diagnostics.F
+++ b/components/mpas-source/src/core_seaice/shared/mpas_seaice_diagnostics.F
@@ -1,3 +1,4 @@
+!!! Add line within seaice core
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  seaice_diagnostics


### PR DESCRIPTION
This is a test PR to show what a PR would look like if we used subtrees rather than submodules for MPAS components. Note that I altered ocean, seaice ,and e3sm files all in this same PR, and line changes are shown below.