### PR TITLE
Test ocean PR: move from MPAS-Model to E3SM

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -929,6 +929,10 @@
 					description="If true, uses Mannings' n values for the computation of Cd=g*n^2*h^{-1/3}."
 					possible_values=".true. or .false."
 		/>
+		<nml_option name="config_use_implicit_bottom_roughness" type="logical" default_value=".false." units="unitless"
+                                        description="If true, depends on bottom roughness z0"
+                                        possible_values=".true. or .false."
+                />
 		<nml_option name="config_use_explicit_bottom_drag" type="logical" default_value=".false." units="unitless"
 					description="If true, explicit bottom drag is used on the momentum equation."
 					possible_values=".true. or .false."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -930,9 +930,9 @@
 					possible_values=".true. or .false."
 		/>
 		<nml_option name="config_use_implicit_bottom_roughness" type="logical" default_value=".false." units="unitless"
-                                        description="If true, depends on bottom roughness z0"
-                                        possible_values=".true. or .false."
-                />
+					description="If true, depends on bottom roughness z0"
+					possible_values=".true. or .false."
+		/>
 		<nml_option name="config_use_explicit_bottom_drag" type="logical" default_value=".false." units="unitless"
 					description="If true, explicit bottom drag is used on the momentum equation."
 					possible_values=".true. or .false."

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -852,7 +852,146 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_vmix_tend_implicit_spatially_variable_mannings!}}}
+!!Nairita
+        subroutine ocn_vel_vmix_tend_implicit_spatially_variable_roughness(meshPool, bottomDrag, dt,kineticEnergyCell, & !{{{
+        vertViscTopOfEdge, layerThickness, &
+        layerThicknessEdge, normalVelocity,ssh, bottomDepth, err)
+        ! input variables
+      !
+      !-----------------------------------------------------------------
 
+      type (mpas_pool_type), intent(in) :: &
+         meshPool          !< Input: mesh information
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         kineticEnergyCell        !< Input: kinetic energy at cell
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         vertViscTopOfEdge !< Input: vertical mixing coefficients
+
+      real (kind=RKIND), intent(in) :: &
+         dt            !< Input: time step
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness !< Input: thickness at cell center
+
+       real (kind=RKIND), dimension(:), intent(in) :: &
+         bottomDrag !< Input: bottomDrag at cell centeres
+
+        real (kind=RKIND), dimension(:), pointer :: ssh
+
+       real (kind=RKIND), dimension(:), pointer :: bottomDepth
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         normalVelocity             !< Input: velocity
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         layerThicknessEdge        !< Input: thickness at edge
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+        
+        integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      integer :: iEdge, k, cell1, cell2, N, nEdges
+      integer, pointer :: nVertLevels
+      real (kind=RKIND) :: implicitCd
+      integer, dimension(:), pointer :: nEdgesArray
+
+      integer, dimension(:), pointer :: maxLevelEdgeTop
+
+      integer, dimension(:,:), pointer :: cellsOnEdge
+
+      real (kind=RKIND), dimension(:), allocatable :: A, B, C, velTemp
+        
+        err = 0
+
+      if(.not.velVmixOn) return
+
+      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+
+      nEdges = nEdgesArray( 1 )
+
+      allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
+      A(1)=0.0_RKIND
+
+      !$omp do schedule(runtime)
+      do iEdge = 1, nEdges
+        N = maxLevelEdgeTop(iEdge)
+        if (N .gt. 0) then
+        ! Compute A(k), B(k), C(k)
+         ! layerThicknessEdge is computed in compute_solve_diag, and is not
+         ! available yet,
+         ! so recompute layerThicknessEdge here.
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         do k = 1, N
+         layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) &
+         +layerThickness(k,cell2))
+         end do
+
+         ! average cell-based implicit bottom drag following the formulation
+         ! in HYCOM (reference : NCOM's formula for 2D case 
+         !cb(i,j) = max(cbmin, (vonk/log(0.5*depth(i,j)/z0))**2 ))
+        implicitCd =max(0.0025,min(0.16/log(0.5*0.5*((bottomDepth(cell1)+bottomDepth(cell2))/0.001)**2.0),0.1))        
+        !! if((implicitCd.ge.0.1).or.(implicitCd.le.0.0001))then
+        !!implicitCd=0.0025
+        !!endif
+        ! A is lower diagonal term
+        do k = 2, N
+            A(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
+               / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
+               / layerThicknessEdge(k,iEdge)
+         enddo
+
+         ! C is upper diagonal term
+         do k = 1, N-1
+            C(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
+               / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
+               / layerThicknessEdge(k,iEdge)
+         enddo
+
+         ! B is diagonal term
+         B(1) = 1.0_RKIND - C(1)
+         do k = 2, N-1
+            B(k) = 1.0_RKIND - A(k) - C(k)
+         enddo
+        ! Apply bottom drag boundary condition on the viscous term
+         ! second line uses sqrt(2.0*kineticEnergyEdge(k,iEdge))
+         ! use implicitCd from spatially variable bottom drag
+         B(N) = 1.0_RKIND - A(N) + dt*implicitCd &
+              * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) &
+         /layerThicknessEdge(N,iEdge)
+
+         call tridiagonal_solve(A(2:N),B,C(1:N-1),normalVelocity(:,iEdge),velTemp,N)
+
+         normalVelocity(1:N,iEdge) = velTemp(1:N)
+         normalVelocity(N+1:nVertLevels,iEdge) = 0.0_RKIND
+
+        end if
+      end do
+      !$omp end do
+
+      deallocate(A,B,C,velTemp)
+
+        end subroutine
 
 !***********************************************************************
 !
@@ -1100,7 +1239,13 @@ contains
                config_Rayleigh_bottom_friction.or. &
                config_Rayleigh_damping_depth_variable) then
         call ocn_vel_vmix_tend_implicit_rayleigh(meshPool, dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)
+          vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
+      else if (config_use_implicit_bottom_roughness) then
+        ! update bottomDrag via Cd=g*n^2*h^(-1/3)
+        call ocn_vel_vmix_tend_implicit_spatially_variable_roughness( &
+          meshPool,bottomDrag, dt, kineticEnergyCell, &
+          vertViscTopOfEdge, layerThickness, layerThicknessEdge, &
+          normalVelocity, ssh, bottomDepth, err)
       else
         call ocn_vel_vmix_tend_implicit(meshPool, dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -908,7 +908,7 @@ contains
 
       integer :: iEdge, k, cell1, cell2, N, nEdges
       integer, pointer :: nVertLevels
-      real (kind=RKIND) :: implicitCd
+      real (kind=RKIND) :: implicitCd, varmin
       integer, dimension(:), pointer :: nEdgesArray
 
       integer, dimension(:), pointer :: maxLevelEdgeTop
@@ -950,7 +950,8 @@ contains
          ! average cell-based implicit bottom drag following the formulation
          ! in HYCOM (reference : NCOM's formula for 2D case 
          !cb(i,j) = max(cbmin, (vonk/log(0.5*depth(i,j)/z0))**2 ))
-        implicitCd =max(0.0025,min(0.16/log(0.5*0.5*((bottomDepth(cell1)+bottomDepth(cell2))/0.001)**2.0),0.1))        
+        varmin=min(0.16_RKIND/(log(0.5_RKIND*0.5_RKIND*(bottomDepth(cell1)+bottomDepth(cell2))/0.001))**2.0,0.1)
+        implicitCd =max(0.0025_RKIND,varmin)        
         !! if((implicitCd.ge.0.1).or.(implicitCd.le.0.0001))then
         !!implicitCd=0.0025
         !!endif

--- a/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vmix.F
@@ -714,7 +714,7 @@ contains
 
       integer :: iEdge, k, cell1, cell2, N, nEdges
       integer, pointer :: nVertLevels
-      real (kind=RKIND) :: implicitCd
+      real (kind=RKIND) :: implicitCd, varmin
       integer, dimension(:), pointer :: nEdgesArray
 
       integer, dimension(:), pointer :: maxLevelEdgeTop
@@ -804,7 +804,10 @@ contains
          end do
 
          ! average cell-based implicit bottom drag to edges and convert Mannings n to Cd
-         if (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
+         if (config_use_implicit_bottom_roughness) then
+           varmin=min(0.16_RKIND/(log(0.5_RKIND*0.5_RKIND*(bottomDepth(cell1)+bottomDepth(cell2))/0.001))**2.0,0.1)
+           implicitCd =max(0.0025_RKIND,varmin)        
+         elseif (config_use_vegetation_drag .AND. config_use_vegetation_manning_equation) then
            implicitCd = gravity*(0.5_RKIND*(vegetationManning(cell1) + vegetationManning(cell2)))**2.0 * &
             (0.5_RKIND * (ssh(cell1) + ssh(cell2) + bottomDepth(cell1) + bottomDepth(cell2)))**(-1.0_RKIND/3.0_RKIND)
          else
@@ -852,147 +855,7 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine ocn_vel_vmix_tend_implicit_spatially_variable_mannings!}}}
-!!Nairita
-        subroutine ocn_vel_vmix_tend_implicit_spatially_variable_roughness(meshPool, bottomDrag, dt,kineticEnergyCell, & !{{{
-        vertViscTopOfEdge, layerThickness, &
-        layerThicknessEdge, normalVelocity,ssh, bottomDepth, err)
-        ! input variables
-      !
-      !-----------------------------------------------------------------
 
-      type (mpas_pool_type), intent(in) :: &
-         meshPool          !< Input: mesh information
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         kineticEnergyCell        !< Input: kinetic energy at cell
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         vertViscTopOfEdge !< Input: vertical mixing coefficients
-
-      real (kind=RKIND), intent(in) :: &
-         dt            !< Input: time step
-
-      real (kind=RKIND), dimension(:,:), intent(in) :: &
-         layerThickness !< Input: thickness at cell center
-
-       real (kind=RKIND), dimension(:), intent(in) :: &
-         bottomDrag !< Input: bottomDrag at cell centeres
-
-        real (kind=RKIND), dimension(:), pointer :: ssh
-
-       real (kind=RKIND), dimension(:), pointer :: bottomDepth
-
-      !-----------------------------------------------------------------
-      !
-      ! input/output variables
-      !
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         normalVelocity             !< Input: velocity
-
-      real (kind=RKIND), dimension(:,:), intent(inout) :: &
-         layerThicknessEdge        !< Input: thickness at edge
-
-      !-----------------------------------------------------------------
-      !
-      ! output variables
-        
-        integer, intent(out) :: err !< Output: error flag
-
-      !-----------------------------------------------------------------
-      !
-      ! local variables
-      !
-      !-----------------------------------------------------------------
-
-      integer :: iEdge, k, cell1, cell2, N, nEdges
-      integer, pointer :: nVertLevels
-      real (kind=RKIND) :: implicitCd, varmin
-      integer, dimension(:), pointer :: nEdgesArray
-
-      integer, dimension(:), pointer :: maxLevelEdgeTop
-
-      integer, dimension(:,:), pointer :: cellsOnEdge
-
-      real (kind=RKIND), dimension(:), allocatable :: A, B, C, velTemp
-        
-        err = 0
-
-      if(.not.velVmixOn) return
-
-      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', nEdgesArray)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-
-      nEdges = nEdgesArray( 1 )
-
-      allocate(A(nVertLevels),B(nVertLevels),C(nVertLevels),velTemp(nVertLevels))
-      A(1)=0.0_RKIND
-
-      !$omp do schedule(runtime)
-      do iEdge = 1, nEdges
-        N = maxLevelEdgeTop(iEdge)
-        if (N .gt. 0) then
-        ! Compute A(k), B(k), C(k)
-         ! layerThicknessEdge is computed in compute_solve_diag, and is not
-         ! available yet,
-         ! so recompute layerThicknessEdge here.
-         cell1 = cellsOnEdge(1,iEdge)
-         cell2 = cellsOnEdge(2,iEdge)
-         do k = 1, N
-         layerThicknessEdge(k,iEdge) = 0.5_RKIND * (layerThickness(k,cell1) &
-         +layerThickness(k,cell2))
-         end do
-
-         ! average cell-based implicit bottom drag following the formulation
-         ! in HYCOM (reference : NCOM's formula for 2D case 
-         !cb(i,j) = max(cbmin, (vonk/log(0.5*depth(i,j)/z0))**2 ))
-        varmin=min(0.16_RKIND/(log(0.5_RKIND*0.5_RKIND*(bottomDepth(cell1)+bottomDepth(cell2))/0.001))**2.0,0.1)
-        implicitCd =max(0.0025_RKIND,varmin)        
-        !! if((implicitCd.ge.0.1).or.(implicitCd.le.0.0001))then
-        !!implicitCd=0.0025
-        !!endif
-        ! A is lower diagonal term
-        do k = 2, N
-            A(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k,iEdge) &
-               / (layerThicknessEdge(k-1,iEdge) + layerThicknessEdge(k,iEdge)) &
-               / layerThicknessEdge(k,iEdge)
-         enddo
-
-         ! C is upper diagonal term
-         do k = 1, N-1
-            C(k) = -2.0_RKIND*dt*vertViscTopOfEdge(k+1,iEdge) &
-               / (layerThicknessEdge(k,iEdge) + layerThicknessEdge(k+1,iEdge)) &
-               / layerThicknessEdge(k,iEdge)
-         enddo
-
-         ! B is diagonal term
-         B(1) = 1.0_RKIND - C(1)
-         do k = 2, N-1
-            B(k) = 1.0_RKIND - A(k) - C(k)
-         enddo
-        ! Apply bottom drag boundary condition on the viscous term
-         ! second line uses sqrt(2.0*kineticEnergyEdge(k,iEdge))
-         ! use implicitCd from spatially variable bottom drag
-         B(N) = 1.0_RKIND - A(N) + dt*implicitCd &
-              * sqrt(kineticEnergyCell(N,cell1) + kineticEnergyCell(N,cell2)) &
-         /layerThicknessEdge(N,iEdge)
-
-         call tridiagonal_solve(A(2:N),B,C(1:N-1),normalVelocity(:,iEdge),velTemp,N)
-
-         normalVelocity(1:N,iEdge) = velTemp(1:N)
-         normalVelocity(N+1:nVertLevels,iEdge) = 0.0_RKIND
-
-        end if
-      end do
-      !$omp end do
-
-      deallocate(A,B,C,velTemp)
-
-        end subroutine
 
 !***********************************************************************
 !
@@ -1229,8 +1092,9 @@ contains
       call mpas_timer_start('vmix solve momentum', .false.)
       if (config_use_implicit_bottom_drag_variable) then
         call ocn_vel_vmix_tend_implicit_spatially_variable(meshPool, bottomDrag, dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)
-      else if (config_use_implicit_bottom_drag_variable_mannings) then
+          vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
+      else if (config_use_implicit_bottom_drag_variable_mannings.or. &
+               config_use_implicit_bottom_roughness) then
         ! update bottomDrag via Cd=g*n^2*h^(-1/3)
         call ocn_vel_vmix_tend_implicit_spatially_variable_mannings(meshPool, forcingPool, bottomDrag, &
           dt, kineticEnergyCell, &
@@ -1241,12 +1105,6 @@ contains
                config_Rayleigh_damping_depth_variable) then
         call ocn_vel_vmix_tend_implicit_rayleigh(meshPool, dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThicknessEdge, normalVelocity, err)
-      else if (config_use_implicit_bottom_roughness) then
-        ! update bottomDrag via Cd=g*n^2*h^(-1/3)
-        call ocn_vel_vmix_tend_implicit_spatially_variable_roughness( &
-          meshPool,bottomDrag, dt, kineticEnergyCell, &
-          vertViscTopOfEdge, layerThickness, layerThicknessEdge, &
-          normalVelocity, ssh, bottomDepth, err)
       else
         call ocn_vel_vmix_tend_implicit(meshPool, dt, kineticEnergyCell, &
           vertViscTopOfEdge, layerThickness, layerThickEdge, normalVelocity, err)


### PR DESCRIPTION
This PR was created by moving the MPAS PR https://github.com/MPAS-Dev/MPAS-Model/pull/606 over to the test E3SM repo with subtrees. It was easy, and the code changes are the same as before.